### PR TITLE
Fix red coin objective prefix

### DIFF
--- a/src/game/bingo_descriptions.c
+++ b/src/game/bingo_descriptions.c
@@ -468,6 +468,8 @@ void get_collectable_objective_desc(struct BingoObjective *obj, char *desc) {
             strcpy(verb, "Break");
             break;  // hah!
         case BINGO_OBJECTIVE_RED_COIN:
+            strcpy(verb, "Collect");
+            break;
         case BINGO_OBJECTIVE_STARS_MULTIPLE_LEVELS:
             strcpy(verb, "Collect one star in");
             break;


### PR DESCRIPTION
Fixes the wording of the Collect Red Coins objective in the Bingo grid.

Before:
![image](https://user-images.githubusercontent.com/8434006/221734057-3a8c999b-b586-46b9-85f3-d3352b10f7a9.png)

After:
![image](https://user-images.githubusercontent.com/8434006/221734065-3581055d-d2b3-4515-a257-30af954349ed.png)
