### PR TITLE
Fix "Bully the Bullies" big bully bingo trigger

### DIFF
--- a/src/game/behaviors/bully.inc.c
+++ b/src/game/behaviors/bully.inc.c
@@ -292,6 +292,9 @@ void bhv_big_bully_with_minions_init(void) {
 
 void BigBullyWithMinionsLavaDeath(void) {
     if (obj_lava_death() == 1) {
+        if (is_new_kill(BINGO_UPDATE_KILLED_BULLY, o->oBingoId)) {
+            bingo_update(BINGO_UPDATE_KILLED_BULLY);
+        }
         func_802A3004();
         create_star(3700.0f, 600.0f, -5500.0f);
     }


### PR DESCRIPTION
Adds a missing `bingo_update` call to fix the "Bully the Bullies" big bully in LLL not triggering a +1 in the "Kill bullies" bingo objective.

![FixedBully_slimmest](https://user-images.githubusercontent.com/8434006/222994939-855da2ae-54f3-4648-82ef-27c7a1e5e9eb.gif)

Also made sure this bully only registers once, and that it doesn't interfere with the other big bully registering either.