### PR TITLE
Fix off-by-one in unique-level star objective

### DIFF
--- a/src/game/bingo_objective_func.c
+++ b/src/game/bingo_objective_func.c
@@ -254,8 +254,8 @@ s32 objective_stars_multiple_levels(struct BingoObjective *objective, enum Bingo
     s32 old_count = 0;
     enum CourseNum course;
     if (update == BINGO_UPDATE_STAR) {
-        for (course = COURSE_BOB; course < COURSE_RR; course++) {
-            count += bingo_get_course_count(course - 1) > 0 ? 1 : 0;
+        for (course = COURSE_BOB; course <= COURSE_RR; course++) {
+            count += bingo_get_course_count(course) > 0 ? 1 : 0;
         }
         old_count = objective->data.collectableData.gotten;
         objective->data.collectableData.gotten = count;


### PR DESCRIPTION
## Summary
- ensure unique-level star goal includes Rainbow Ride and counts courses correctly

## Testing
- `make -j4 build/us/src/game/bingo_objective_func.o` *(fails: Failed to open baserom.us.z64)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fe1f880c83319166ad58ca30844c