### PR TITLE
Add test warp seam: jump straight to any level's star select

### DIFF
--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -647,6 +647,23 @@ struct WarpNode *get_painting_warp_node(void) {
     return warpNode;
 }
 
+// Test harnesses write a level number here from outside the game (via the
+// emulator debugger). Nothing in the game itself ever sets it. The warp acts
+// like stepping into that level's painting, so the star select screen still
+// appears for normal courses. See test/README.md.
+s32 gTestWarpRequest = 0;
+
+static void initiate_test_warp(void) {
+    s16 destLevel = gTestWarpRequest;
+    gTestWarpRequest = 0;
+
+    initiate_warp(destLevel, 1, 0x0A, 0);
+    play_transition_after_delay(WARP_TRANSITION_FADE_INTO_COLOR, 30, 255, 255, 255, 45);
+    level_set_transition(74, basic_update);
+    set_mario_action(gMarioState, ACT_DISAPPEARED, 0);
+    gMarioState->marioObj->header.gfx.node.flags &= ~0x0001;
+}
+
 /**
  * Check is mario has entered a painting, and if so, initiate a warp.
  */
@@ -986,6 +1003,11 @@ s32 play_mode_normal(void) {
 
     if (gCurrentArea != NULL) {
         update_camera(gCurrentArea->camera);
+    }
+
+    if (gTestWarpRequest != 0 && !gWarpTransition.isActive && sDelayedWarpOp == WARP_OP_NONE
+        && sWarpDest.type == WARP_TYPE_NOT_WARPING) {
+        initiate_test_warp();
     }
 
     initiate_painting_warp();

--- a/src/game/level_update.h
+++ b/src/game/level_update.h
@@ -79,6 +79,9 @@ struct WarpDest {
 
 extern struct WarpDest sWarpDest;
 
+// Only test harnesses write this; see initiate_test_warp in level_update.c.
+extern s32 gTestWarpRequest;
+
 extern s16 D_80339EE0;
 extern s16 sDelayedWarpOp;
 extern s16 sDelayedWarpTimer;

--- a/test/README.md
+++ b/test/README.md
@@ -8,6 +8,7 @@ features can be added or changed without hand-testing in an emulator.
 | Unit tests | `test/host` | ~2 s | The bingo logic is right |
 | Smoke test | `test/emu` (`make test-smoke`) | ~1 min | The ROM boots, plays, renders |
 | RAM test | `test/emu` (`make test-ram`) | ~1 min | The running ROM agrees with the unit-tested logic |
+| Warp test | `test/emu` (`make test-warp`) | ~1 min | Tests can jump straight into any course |
 
 ## Running
 
@@ -41,6 +42,27 @@ the ROM you just built.
 The RAM test looks up global variables in `build/us/sm64.us.map`, reads
 them out of emulated memory mid-run, and diffs the live board against the
 host generator's output for the same seed.
+
+## Warping into levels
+
+Walking from the castle to a course in an input script is slow and
+fragile. Instead the game has one test-only global, `gTestWarpRequest`
+(in `level_update.c`). Nothing in the game writes it; when a test
+harness pokes a level number into it through the emulator debugger, the
+game warps there through the same code as stepping into a painting. The
+star select screen appears as normal, so a script can pick any act —
+that is how act-specific objectives (click game, timed stars) can be
+reached directly.
+
+The recipe, from `warp_test.py` and `scripts/warp_bob.txt`: boot with
+the usual script, write the level number at frame 450, star select is up
+by ~530, an A press at frame 700 lands Mario in the course by ~720.
+Total: about 12 seconds of emulated time to be standing in any level.
+
+Levels are numbered by `levels/level_defines.h` order (BOB=9, CCM=5,
+WF=24). Poking works on every fresh build because addresses come from
+the linker map, which regenerates with the ROM — this is why RAM pokes
+are fine where savestates are not.
 
 ## Golden files, and when tests "fail" on purpose
 

--- a/test/emu/Makefile
+++ b/test/emu/Makefile
@@ -7,9 +7,9 @@
 M64P_SRC ?= $(HOME)/opt/m64p/mupen64plus-core/src/api
 BUILD := build
 
-.PHONY: test test-smoke test-ram plugin clean
+.PHONY: test test-smoke test-ram test-warp plugin clean
 
-test: test-smoke test-ram
+test: test-smoke test-ram test-warp
 
 plugin: $(BUILD)/input_script.so
 
@@ -25,6 +25,9 @@ test-smoke: plugin
 # Needs the core built with DEBUGGER=1 for RAM reads.
 test-ram: plugin
 	xvfb-run -a python3 ram_test.py
+
+test-warp: plugin
+	xvfb-run -a python3 warp_test.py
 
 clean:
 	rm -rf $(BUILD)

--- a/test/emu/m64p_core.py
+++ b/test/emu/m64p_core.py
@@ -37,6 +37,8 @@ class Core:
         self.lib.DebugMemRead32.argtypes = [ctypes.c_uint]
         self.lib.DebugMemRead8.restype = ctypes.c_ubyte
         self.lib.DebugMemRead8.argtypes = [ctypes.c_uint]
+        self.lib.DebugMemWrite32.restype = None
+        self.lib.DebugMemWrite32.argtypes = [ctypes.c_uint, ctypes.c_uint]
 
         self._debug_cb = DEBUG_CB(self._on_debug)
         self._state_cb = STATE_CB(lambda ctx, p, v: None)
@@ -90,6 +92,9 @@ class Core:
 
     def read_u32(self, addr):
         return self.lib.DebugMemRead32(ctypes.c_uint(addr))
+
+    def write_u32(self, addr, value):
+        self.lib.DebugMemWrite32(ctypes.c_uint(addr), ctypes.c_uint(value & 0xFFFFFFFF))
 
     def read_s32(self, addr):
         v = self.read_u32(addr)

--- a/test/emu/scripts/warp_bob.txt
+++ b/test/emu/scripts/warp_bob.txt
@@ -1,0 +1,5 @@
+# Boot to gameplay (same timing as boot_and_board.txt), then the harness
+# warps to BOB at frame 450. Star select is up by ~530; A picks star 1.
+150 155 START
+320 322 A
+700 702 A

--- a/test/emu/warp_test.py
+++ b/test/emu/warp_test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Checks the test warp seam: writing a level number to gTestWarpRequest
+makes the game warp there through its own painting-entry code.
+
+The run boots to castle grounds, then the harness writes LEVEL_BOB into
+gTestWarpRequest. The game must show the star select screen (so tests can
+pick a specific act), and after the scripted A press Mario must be
+standing in the course.
+
+Run under xvfb (make test-warp does this).
+"""
+
+import os
+import sys
+import tempfile
+
+import m64p_core
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.join(HERE, "..", "..")
+ROM = os.path.join(REPO, "build", "us", "sm64.us.f3dex.z64")
+MAP = os.path.join(REPO, "build", "us", "sm64.us.map")
+
+LEVEL_CASTLE_GROUNDS = 16
+LEVEL_BOB = 9
+COURSE_BOB = 1
+
+failures = []
+
+
+def check(cond, message):
+    if not cond:
+        failures.append(message)
+        print("  check failed: %s" % message)
+
+
+def main():
+    if not os.path.exists(ROM):
+        print("missing %s -- run the main build first" % ROM)
+        return 1
+
+    syms = m64p_core.load_map_symbols(MAP, [
+        "gTestWarpRequest", "gCurrLevelNum", "gCurrCourseNum", "gCurrActNum",
+        "gGlobalTimer", "gMarioObject",
+    ])
+
+    os.environ.pop("WAYLAND_DISPLAY", None)
+    os.environ["SDL_VIDEODRIVER"] = "x11"
+    os.environ["SDL_AUDIODRIVER"] = "dummy"
+    os.environ["BINGO_INPUT_SCRIPT"] = os.path.join(HERE, "scripts", "warp_bob.txt")
+
+    core = m64p_core.Core(
+        os.environ.get("M64P", os.path.expanduser("~/opt/m64p/install")),
+        tempfile.mkdtemp(prefix="bingo64_warp_cfg_"))
+    core.load_rom(ROM)
+    core.attach_standard_plugins(os.path.join(HERE, "build", "input_script.so"))
+
+    def read_s16(addr):
+        b = core.read_bytes(addr, 2)
+        v = (b[0] << 8) | b[1]
+        return v - 0x10000 if v >= 0x8000 else v
+
+    state = {"timer_at_60": None}
+
+    def on_frame(frame):
+        if frame == 60:
+            state["timer_at_60"] = core.read_u32(syms["gGlobalTimer"])
+        elif frame == 120:
+            t2 = core.read_u32(syms["gGlobalTimer"])
+            check(state["timer_at_60"] is not None and t2 > state["timer_at_60"],
+                  "gGlobalTimer not advancing (%r -> %r)" % (state["timer_at_60"], t2))
+        elif frame == 440:
+            check(read_s16(syms["gCurrLevelNum"]) == LEVEL_CASTLE_GROUNDS,
+                  "not in castle grounds before the warp")
+        elif frame == 450:
+            core.write_u32(syms["gTestWarpRequest"], LEVEL_BOB)
+        elif frame == 600:
+            # Star select screen: right level and course, no act chosen yet,
+            # Mario despawned, and the game consumed the request.
+            check(read_s16(syms["gCurrLevelNum"]) == LEVEL_BOB, "warp did not reach BOB")
+            check(read_s16(syms["gCurrCourseNum"]) == COURSE_BOB, "course number wrong")
+            check(read_s16(syms["gCurrActNum"]) == 0, "act chosen before star select")
+            check(core.read_u32(syms["gMarioObject"]) == 0, "mario present on star select")
+            check(core.read_u32(syms["gTestWarpRequest"]) == 0, "warp request not cleared")
+        elif frame == 750:
+            # After the scripted A press: act 1 picked, Mario spawned in BOB.
+            check(read_s16(syms["gCurrActNum"]) == 1, "act not selected")
+            check(core.read_u32(syms["gMarioObject"]) != 0, "mario not spawned in BOB")
+        elif frame >= 760:
+            core.stop()
+
+    core.run(on_frame)
+    core.shutdown()
+
+    if failures:
+        print("WARP TEST FAILED (%d problems)" % len(failures))
+        return 1
+    print("warp test ok (castle grounds -> star select -> BOB act 1)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacked on #7.

Walking from the castle to a course in a scripted input recording is slow and fragile. This adds one test-only global, `gTestWarpRequest`: nothing in the game writes it, but when a test harness pokes a level number into it through the emulator debugger, the game warps there through the same code path as stepping into a painting. The star select screen appears as normal, so scripts can pick specific acts (click game, timed stars, …).

Timing with the committed `scripts/warp_bob.txt`: boot → poke at frame 450 → star select by ~530 → scripted A at 700 → Mario standing in BOB act 1 at ~720. About 12 seconds of emulated time to reach any course.

`make test-warp` (new, included in `make test`) verifies the full chain: castle grounds → request consumed → star select with Mario despawned → act selected → Mario spawned in BOB. The existing smoke/RAM tests still pass with unchanged goldens and seed, confirming the seam is inert unless poked.

Why pokes are safe where savestates were not: addresses come from the linker map, which regenerates with every build — nothing stale can leak in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cwn9Rv3q2xicMJDYnXbbGy