### PR TITLE
Board-generator website: real bingo C compiled to WASM, deployed to GitHub Pages

### DIFF
--- a/.github/workflows/web-check.yml
+++ b/.github/workflows/web-check.yml
@@ -1,0 +1,56 @@
+# Verifies the web board generator: the WASM build of the bingo C code must
+# produce byte-identical boards to the gcc-built oracle and the goldens.
+#
+# No baserom is needed. The only baserom-derived inputs the bingo slice uses
+# are two vanilla HUD textures (star, coin); their bytes affect how icons
+# look, never board content, so CI stubs them with zeros.
+
+name: web-generator
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libaudiofile-dev
+
+      - name: Install Emscripten
+        run: |
+          git clone --depth 1 https://github.com/emscripten-core/emsdk.git ~/opt/emsdk
+          ~/opt/emsdk/emsdk install latest
+          ~/opt/emsdk/emsdk activate latest
+
+      - name: Generate build prerequisites
+        run: |
+          targets="build/us/include/text_strings.h build/us/text/us/define_text.inc.c"
+          for tex in $(grep -o '"textures/[^"]*"' src/game/bingo_objective_info.c | tr -d '"'); do
+            targets="$targets build/us/$tex"
+          done
+          for t in $targets; do
+            case "$t" in
+              build/us/textures/*)
+                png="${t#build/us/}"
+                png="${png%.inc.c}.png"
+                if [ ! -f "$png" ]; then
+                  mkdir -p "$(dirname "$t")"
+                  python3 -c "print('0x0,' * 512)" > "$t"
+                fi
+                ;;
+            esac
+          done
+          make QEMU_IRIX=true NOEXTRACT=1 GRUCODE=f3dex $targets
+
+      - name: Host unit tests
+        run: make -C test/host test
+
+      - name: Build WASM generator and verify against the oracle
+        run: make -C web check

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -1,20 +1,28 @@
-# Verifies the web board generator: the WASM build of the bingo C code must
-# produce byte-identical boards to the gcc-built oracle and the goldens.
-#
-# No baserom is needed. The only baserom-derived inputs the bingo slice uses
-# are two vanilla HUD textures (star, coin); their bytes affect how icons
-# look, never board content, so CI stubs them with zeros.
+# Builds the board-generator website and publishes it to GitHub Pages.
+# Runs on every master push; use "Run workflow" to deploy another branch.
 
-name: web-generator
+name: web-deploy
 
 on:
   push:
     branches: [master]
-  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
-  check:
+  deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -35,8 +43,14 @@ jobs:
           WEB_TEX_COIN_05800: ${{ vars.WEB_TEX_COIN_05800 }}
         run: bash web/ci_prereqs.sh
 
-      - name: Host unit tests
-        run: make -C test/host test
+      - name: Build WASM generator
+        run: make -C web wasm
 
-      - name: Build WASM generator and verify against the oracle
-        run: make -C web check
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/site
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/plans/online-bingo.md
+++ b/plans/online-bingo.md
@@ -1,6 +1,7 @@
 # Plan: Online Bingo64
 
-Status: agreed 2026-08-08. Work has not started.
+Status: agreed 2026-08-08. Part A is done (see `web/`), with the Bingosync
+goal export from part B. Parts B (step 2) and D have not started.
 
 Note: this document uses ASD-STE100 (Simplified Technical English) style.
 

--- a/test/host/test_bingo.c
+++ b/test/host/test_bingo.c
@@ -606,10 +606,37 @@ static void test_win_detection(void) {
 
 int main(void) {
     // BOARD_SEED=n prints that board instead of running tests. Handy for
-    // comparing against what the ROM shows on screen.
+    // comparing against what the ROM shows on screen, and used as the
+    // oracle by web/check.mjs. BOARD_TARGET=n (1, 2, 3, or 12) and
+    // BOARD_DISABLE=t1,t2,... (objective type numbers) set the same options
+    // the file select screen offers.
     const char *seedArg = getenv("BOARD_SEED");
     if (seedArg != NULL) {
+        const char *targetArg = getenv("BOARD_TARGET");
+        const char *disableArg = getenv("BOARD_DISABLE");
+        if (disableArg != NULL) {
+            char *end;
+            while (*disableArg != '\0') {
+                long type = strtol(disableArg, &end, 10);
+                if (end == disableArg) {
+                    break;
+                }
+                if (type >= 0 && type < BINGO_OBJECTIVE_TOTAL_AMOUNT) {
+                    gBingoObjectivesDisabled[type] = 1;
+                }
+                disableArg = (*end == ',') ? end + 1 : end;
+            }
+        }
         generate_board((u32) strtoul(seedArg, NULL, 10));
+        if (targetArg != NULL) {
+            // generate_board pins the target to 1; redo setup with the
+            // requested target, exactly like a fresh boot with that option.
+            save_or_restore_weights();
+            memset(gBingoObjectives, 0, sizeof(gBingoObjectives));
+            gbBingoTarget = (s32) strtol(targetArg, NULL, 10);
+            gbBingosCompleted = 0;
+            setup_bingo_objectives((u32) strtoul(seedArg, NULL, 10));
+        }
         dump_board(stdout);
         return 0;
     }

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,2 @@
+build/
+site/dist/

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,0 +1,92 @@
+# Web board generator: compiles the real bingo C to WebAssembly.
+#
+# Same layout as test/host: the game sources are copied into build/ before
+# compiling so the stub headers in ../test/host/stubs win over the real game
+# headers for "quoted" includes.
+#
+# Needs:
+#  - the Emscripten SDK (default ~/opt/emsdk; override with EMSDK=...)
+#  - the main ROM build run at least once (make in the repo root), for
+#    text_strings.h, the generated name tables, and the icon texture data.
+
+REPO := ..
+BUILD := build
+DIST := site/dist
+
+EMSDK ?= $(HOME)/opt/emsdk
+EMCC ?= $(EMSDK)/upstream/emscripten/emcc
+# emsdk refuses pythons older than 3.10; pick a modern one if present.
+export EMSDK_PYTHON ?= $(shell command -v python3.11 || command -v python3.12 || command -v python3)
+
+GEN_VERSION := $(shell git -C $(REPO) describe --always --dirty 2>/dev/null || echo dev)
+
+GAME_SRCS := \
+	rand.c \
+	strcpy.c \
+	bingo.c \
+	bingo_board_setup.c \
+	bingo_objective_init.c \
+	bingo_objective_func.c \
+	bingo_objective_info.c \
+	bingo_const.c \
+	bingo_titles.c \
+	bingo_descriptions.c \
+	bingo_tracking_collectables.c \
+	bingo_tracking_star.c
+
+WEB_SRCS := shims.c wasm_api.c
+
+INCLUDES := -I $(REPO)/test/host/stubs -I $(REPO)/src/game -I $(REPO)/src \
+	-I $(REPO)/include -I $(REPO) -I $(REPO)/build/us -I $(REPO)/build/us/include
+CFLAGS := -O2 -fno-builtin -DVERSION_US -DF3DEX_GBI -DNON_MATCHING -DAVOID_UB \
+	-DGEN_VERSION='"$(GEN_VERSION)"' $(INCLUDES)
+
+GAME_OBJS := $(GAME_SRCS:%.c=$(BUILD)/%.o)
+WEB_OBJS := $(WEB_SRCS:%.c=$(BUILD)/%.o)
+
+.PHONY: wasm check serve clean
+
+wasm: $(DIST)/bingo64gen.mjs
+
+$(BUILD) $(DIST):
+	mkdir -p $@
+
+$(REPO)/build/us/include/text_strings.h:
+	$(error Run the main ROM build first (make in the repo root))
+
+$(BUILD)/rand.c: $(REPO)/src/engine/rand.c | $(BUILD)
+	cp $< $@
+
+$(BUILD)/%.c: $(REPO)/src/game/%.c | $(BUILD)
+	cp $< $@
+
+# Game code compiles with warnings silenced; it is not ours to fix here.
+# Recent clang upgrades some 1990s C patterns to errors; downgrade those.
+GAME_WARNFLAGS := -w -Wno-error=return-mismatch -Wno-error=incompatible-pointer-types \
+	-Wno-error=implicit-function-declaration -Wno-error=implicit-int
+
+$(BUILD)/%.o: $(BUILD)/%.c $(REPO)/build/us/include/text_strings.h
+	$(EMCC) $(CFLAGS) $(GAME_WARNFLAGS) -c -o $@ $<
+
+$(BUILD)/%.o: gen/%.c | $(BUILD)
+	$(EMCC) $(CFLAGS) -Wall -Wextra -c -o $@ $<
+
+$(DIST)/bingo64gen.mjs: $(GAME_OBJS) $(WEB_OBJS) | $(DIST)
+	$(EMCC) -O2 -o $@ $(GAME_OBJS) $(WEB_OBJS) \
+		-sMODULARIZE=1 -sEXPORT_ES6=1 \
+		-sENVIRONMENT=web,worker,node \
+		-sALLOW_MEMORY_GROWTH=1 \
+		-sEXPORTED_FUNCTIONS=_gen_board_json,_gen_board_dump,_gen_options_json,_gen_icon_rgba16,_gen_num_objective_types,_gen_version,_malloc,_free \
+		-sEXPORTED_RUNTIME_METHODS=UTF8ToString,HEAPU8
+
+# Byte-compares the WASM generator against the goldens and against the
+# gcc-built oracle in test/host, across many seeds and option combinations.
+check: $(DIST)/bingo64gen.mjs
+	$(MAKE) -C $(REPO)/test/host build/run_tests
+	node check.mjs
+
+serve: wasm
+	cd site && python3 -m http.server 8064
+
+clean:
+	rm -rf $(BUILD) $(DIST)

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,58 @@
+# Bingo64 web board generator
+
+A static website that generates the exact board the game makes for a seed.
+It is not a reimplementation: the real bingo C code (`src/game/bingo*.c`,
+`src/engine/rand.c`) is compiled to WebAssembly with Emscripten, reusing the
+`test/host` stub layer. Part A (and half of part B) of
+`plans/online-bingo.md`.
+
+What the page does:
+
+- Seed (1–9 digits), game mode (1/2/3 bingos, blackout), and per-objective
+  on/off toggles — the same inputs the game's file select screen offers.
+- Renders the 5x5 board with the real in-game icons (texture bytes exported
+  straight from the compiled data) and in-game titles; hover a cell for the
+  full description. Boards are shareable as permalinks (`#s=...&t=...`).
+- Exports the 25 goals as Bingosync "Custom (Advanced)" JSON: on
+  bingosync.com, Make Room → Game: Custom (Advanced) → paste. (Creating the
+  room automatically from this page is not possible: bingosync has no CORS
+  API. A goal-list generator PR to bingosync is the plan's optional step 2.)
+
+## Building
+
+Needs the Emscripten SDK (default location `~/opt/emsdk`, override with
+`EMSDK=...`) and the generated build inputs (text tables, icon textures).
+If you have run the main ROM build once, you already have those inputs.
+Without a baserom they can be generated directly — see the "Generate build
+prerequisites" step in `.github/workflows/web-check.yml`.
+
+```
+make wasm    # build site/dist/bingo64gen.{mjs,wasm}
+make serve   # build + serve the site on http://localhost:8064
+make check   # byte-compare against test/host goldens + gcc oracle
+```
+
+`make check` proves the WASM generator equals the game's code: the 3 golden
+boards byte-exact, 200 random seeds, and 60 random option combinations
+(target + disabled objectives) against the gcc-built `test/host` oracle in
+`BOARD_SEED`/`BOARD_TARGET`/`BOARD_DISABLE` mode. CI runs this on every PR.
+
+## Layout
+
+- `gen/wasm_api.c` — the JS-facing exports. Boards cross the boundary as
+  JSON; icons as raw RGBA16 bytes; a dump export replicates the golden-file
+  format for `check.mjs`.
+- `gen/shims.c` — same fakes as `test/host/glue.c`, but with the real
+  course/act name tables (from the generated `define_text.inc.c`) so
+  descriptions use real level and star names.
+- `site/` — the static page. `site/dist/` (gitignored) holds the built
+  module.
+- `check.mjs` — the equivalence checker run by `make check`.
+
+## Versioning (future)
+
+The plan calls for one generator version per game release, selectable on the
+site. The current page serves a single build (its version, from
+`git describe`, is shown in the footer and embedded in every board JSON).
+When the next game release happens, move `site/dist` to
+`site/dist/<version>/` with a manifest, and add a version picker.

--- a/web/check.mjs
+++ b/web/check.mjs
@@ -1,0 +1,104 @@
+// Compares the WASM generator against the repository's other builds of the
+// same C code:
+//
+//  1. The golden boards in test/host/golden/ (byte-exact).
+//  2. The gcc-built oracle (test/host/build/run_tests, BOARD_SEED mode)
+//     across many seeds, bingo targets, and disabled-objective sets.
+//
+// Run via `make check` (which builds both sides first).
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import createModule from './site/dist/bingo64gen.mjs';
+
+const ORACLE_CWD = '../test/host';
+const ORACLE = 'build/run_tests'; // relative to ORACLE_CWD
+const SWEEP_SEEDS = 200;
+const OPTION_SWEEP_SEEDS = 60;
+
+const M = await createModule();
+const NUM_TYPES = M._gen_num_objective_types();
+
+// The dump contains raw in-game glyph bytes (e.g. 0xFA), which are not valid
+// UTF-8, so read the C string byte-by-byte instead of via UTF8ToString.
+function cStringBytes(ptr) {
+  const heap = M.HEAPU8;
+  let end = ptr;
+  while (heap[end] !== 0) end++;
+  return Buffer.from(heap.subarray(ptr, end));
+}
+
+function wasmDump(seed, target, disabledTypes) {
+  let disabledPtr = 0;
+  if (disabledTypes.length > 0) {
+    disabledPtr = M._malloc(NUM_TYPES);
+    M.HEAPU8.fill(0, disabledPtr, disabledPtr + NUM_TYPES);
+    for (const t of disabledTypes) M.HEAPU8[disabledPtr + t] = 1;
+  }
+  const bytes = cStringBytes(M._gen_board_dump(seed, target, disabledPtr));
+  if (disabledPtr) M._free(disabledPtr);
+  return bytes;
+}
+
+function oracleDump(seed, target, disabledTypes) {
+  const env = { ...process.env, BOARD_SEED: String(seed) };
+  if (target !== 1) env.BOARD_TARGET = String(target);
+  if (disabledTypes.length > 0) env.BOARD_DISABLE = disabledTypes.join(',');
+  return execFileSync(ORACLE, { cwd: ORACLE_CWD, env });
+}
+
+// Deterministic PRNG so failures reproduce.
+let rngState = 0x12345678;
+function rng() {
+  rngState = (Math.imul(rngState, 1103515245) + 12345) >>> 0;
+  return rngState;
+}
+
+let failures = 0;
+function compare(name, a, b) {
+  if (Buffer.compare(a, b) === 0) return;
+  failures++;
+  console.error(`MISMATCH: ${name}`);
+  const al = a.toString('latin1').split('\n');
+  const bl = b.toString('latin1').split('\n');
+  for (let i = 0; i < Math.max(al.length, bl.length); i++) {
+    if (al[i] !== bl[i]) {
+      console.error(`  wasm  : ${JSON.stringify(al[i])}`);
+      console.error(`  oracle: ${JSON.stringify(bl[i])}`);
+      break;
+    }
+  }
+}
+
+// 1. Goldens.
+for (const seed of [1, 12345, 314159]) {
+  const golden = readFileSync(`../test/host/golden/board_${seed}.txt`);
+  compare(`golden seed ${seed}`, wasmDump(seed, 1, []), golden);
+}
+console.log('golden boards: checked 3');
+
+// 2. Seed sweep against the oracle, default options.
+for (let i = 0; i < SWEEP_SEEDS; i++) {
+  const seed = rng() % 1000000000;
+  compare(`seed ${seed}`, wasmDump(seed, 1, []), oracleDump(seed, 1, []));
+}
+console.log(`seed sweep: checked ${SWEEP_SEEDS}`);
+
+// 3. Option sweep: random target and random disabled set per seed.
+const TARGETS = [1, 2, 3, 12];
+for (let i = 0; i < OPTION_SWEEP_SEEDS; i++) {
+  const seed = rng() % 1000000000;
+  const target = TARGETS[rng() % TARGETS.length];
+  const disabled = [];
+  const nDisable = rng() % 8;
+  for (let j = 0; j < nDisable; j++) disabled.push(rng() % NUM_TYPES);
+  const name = `seed ${seed} target ${target} disable [${disabled.join(',')}]`;
+  compare(name, wasmDump(seed, target, disabled), oracleDump(seed, target, disabled));
+}
+console.log(`option sweep: checked ${OPTION_SWEEP_SEEDS}`);
+
+if (failures > 0) {
+  console.error(`FAILED: ${failures} mismatch(es)`);
+  process.exit(1);
+}
+console.log('all checks passed');

--- a/web/ci_prereqs.sh
+++ b/web/ci_prereqs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Generates the ROM-build inputs the web and test/host builds need, without a
+# baserom: the encoded text tables and the icon texture data. Used by the
+# GitHub workflows; harmless to run locally too.
+#
+# Almost every icon texture is a custom PNG committed to the repo. The two
+# vanilla ones (HUD star and coin) are extracted from the baserom, so CI
+# cannot regenerate them; their generated .inc.c contents can be supplied via
+# the WEB_TEX_STAR_05C00 / WEB_TEX_COIN_05800 environment variables (set as
+# repository variables on GitHub). Without them, zero stubs are used: board
+# content is unaffected, those two icons just render blank.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+write_tex() { # $1 = texture path under build/us, $2 = contents (may be empty)
+    if [ -f "build/us/$1" ] && [ -z "$2" ]; then
+        return # keep an existing real file over a stub
+    fi
+    mkdir -p "$(dirname "build/us/$1")"
+    if [ -n "$2" ]; then
+        printf '%s' "$2" > "build/us/$1"
+    else
+        python3 -c "print('0x0,' * 512)" > "build/us/$1"
+    fi
+}
+
+write_tex textures/segment2/segment2.05C00.rgba16.inc.c "${WEB_TEX_STAR_05C00:-}"
+write_tex textures/segment2/segment2.05800.rgba16.inc.c "${WEB_TEX_COIN_05800:-}"
+
+targets="build/us/include/text_strings.h build/us/text/us/define_text.inc.c"
+for tex in $(grep -o '"textures/[^"]*"' src/game/bingo_objective_info.c | tr -d '"'); do
+    png="${tex%.inc.c}.png"
+    if [ ! -f "$png" ] && [ ! -f "build/us/$tex" ]; then
+        write_tex "$tex" "" # future baserom-derived texture: stub it
+    fi
+    targets="$targets build/us/$tex"
+done
+
+make QEMU_IRIX=true NOEXTRACT=1 GRUCODE=f3dex $targets

--- a/web/gen/shims.c
+++ b/web/gen/shims.c
@@ -1,0 +1,84 @@
+// Web build glue: the same fakes as test/host/glue.c, minus the test
+// counters, and with one big difference: the course and act name tables are
+// the real ones from the generated text data, so objective descriptions on
+// the website show the real level and star names.
+
+#include <ultra64.h>
+#include "types.h"
+
+s16 gCurrCourseNum = 0;
+s16 gCurrLevelNum = 0;
+s16 gTTCSpeedSetting = 0;
+s16 sSelectionFlags = 0;
+s8 gDialogCameraAngleIndex = 0;
+f32 gDefaultSoundArgs[3] = { 0 };
+
+const BehaviorScript bhv1upGreenDemon[] = { 0 };
+
+void *segmented_to_virtual(void *addr) {
+    return addr;
+}
+
+void play_sound(s32 soundBits, f32 *pos) {
+    (void) soundBits;
+    (void) pos;
+}
+
+void bingo_hud_update_message(s32 icon, char message[10], s8 horribleHackWallkick) {
+    (void) icon;
+    (void) message;
+    (void) horribleHackWallkick;
+}
+
+void bingo_hud_update_number(s32 icon, s32 number) {
+    (void) icon;
+    (void) number;
+}
+
+void bingo_hud_update_state(s32 icon, s32 state) {
+    (void) icon;
+    (void) state;
+}
+
+struct Object *obj_nearest_object_with_behavior(const BehaviorScript *behavior) {
+    (void) behavior;
+    return NULL;
+}
+
+void mark_object_for_deletion(struct Object *obj) {
+    (void) obj;
+}
+
+s32 gSplatoonEnabled = 0;
+s32 gSplatoonPaintedCount = 0;
+s32 gSplatoonTotalFloors = 0;
+
+void splatoon_clear(void) {
+    gSplatoonPaintedCount = 0;
+    gSplatoonTotalFloors = 0;
+}
+
+// Same as the game's RandomU16 in behavior_script.c: low 16 bits of the
+// Mersenne Twister output.
+unsigned long genrand_int32(void);
+
+u32 RandomU32(void) {
+    return genrand_int32();
+}
+
+u16 RandomU16(void) {
+    return (u16) RandomU32();
+}
+
+// The real course/act name tables. The main ROM build generates this file
+// with the in-game encoded strings already substituted, so descriptions can
+// decode them with reverse_encode_str exactly like the game does.
+struct DialogEntry {
+    u32 unused;
+    s8 linesPerBox;
+    s16 leftOffset;
+    s16 width;
+    const u8 *str;
+};
+
+#include "text/us/define_text.inc.c"

--- a/web/gen/wasm_api.c
+++ b/web/gen/wasm_api.c
@@ -1,0 +1,299 @@
+// JavaScript-facing API for the board generator.
+//
+// Everything crosses the JS boundary as JSON text or raw texture bytes, so
+// the JS side never depends on C struct layout. The generation entry point
+// mirrors what the game does on file select: set the options, then call
+// setup_bingo_objectives(seed).
+
+#include <ultra64.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <emscripten.h>
+
+#include "bingo.h"
+#include "bingo_descriptions.h"
+#include "bingo_objective_info.h"
+#include "engine/rand.h"
+
+void setup_bingo_objectives(u32 seed);
+
+#ifndef GEN_VERSION
+#define GEN_VERSION "dev"
+#endif
+
+// ---------------------------------------------------------------------------
+// Fresh-boot weight tables, same trick as test/host/test_bingo.c: the board
+// setup mutates its "uses remaining" counters, so save the pristine tables
+// once and put them back before every board.
+
+struct ObjectiveWeight {
+    s32 objective;
+    s32 weight;
+    s32 usesRemaining;
+};
+extern struct ObjectiveWeight sWeightsEasy[], sWeightsMedium[], sWeightsHard[], sWeightsCenter[];
+extern s32 sWeightsSizeEasy, sWeightsSizeMedium, sWeightsSizeHard, sWeightsSizeCenter;
+
+#define MAX_WEIGHTS 64
+static struct ObjectiveWeight sSavedEasy[MAX_WEIGHTS], sSavedMedium[MAX_WEIGHTS],
+                              sSavedHard[MAX_WEIGHTS], sSavedCenter[MAX_WEIGHTS];
+static int sWeightsSaved = 0;
+
+static void save_or_restore_weights(void) {
+    if (!sWeightsSaved) {
+        memcpy(sSavedEasy, sWeightsEasy, sWeightsSizeEasy * sizeof(struct ObjectiveWeight));
+        memcpy(sSavedMedium, sWeightsMedium, sWeightsSizeMedium * sizeof(struct ObjectiveWeight));
+        memcpy(sSavedHard, sWeightsHard, sWeightsSizeHard * sizeof(struct ObjectiveWeight));
+        memcpy(sSavedCenter, sWeightsCenter, sWeightsSizeCenter * sizeof(struct ObjectiveWeight));
+        sWeightsSaved = 1;
+    } else {
+        memcpy(sWeightsEasy, sSavedEasy, sWeightsSizeEasy * sizeof(struct ObjectiveWeight));
+        memcpy(sWeightsMedium, sSavedMedium, sWeightsSizeMedium * sizeof(struct ObjectiveWeight));
+        memcpy(sWeightsHard, sSavedHard, sWeightsSizeHard * sizeof(struct ObjectiveWeight));
+        memcpy(sWeightsCenter, sSavedCenter, sWeightsSizeCenter * sizeof(struct ObjectiveWeight));
+    }
+}
+
+static void generate(u32 seed, s32 target, const u8 *disabled) {
+    int i;
+    save_or_restore_weights();
+    memset(gBingoObjectives, 0, sizeof(gBingoObjectives));
+    for (i = 0; i < BINGO_OBJECTIVE_TOTAL_AMOUNT; i++) {
+        gBingoObjectivesDisabled[i] = disabled != NULL ? disabled[i] : 0;
+    }
+    gbBingoTarget = target;
+    gbBingosCompleted = 0;
+    setup_bingo_objectives(seed);
+}
+
+// ---------------------------------------------------------------------------
+// Output buffer with JSON helpers.
+
+static char sBuf[131072];
+static size_t sLen;
+
+static void emitf(const char *fmt, ...) {
+    va_list ap;
+    int n;
+    va_start(ap, fmt);
+    n = vsnprintf(sBuf + sLen, sizeof(sBuf) - sLen, fmt, ap);
+    va_end(ap);
+    if (n > 0 && sLen + n < sizeof(sBuf)) {
+        sLen += n;
+    }
+}
+
+// Bytes outside printable ASCII become \u00xx escapes, so in-game glyph
+// bytes (like the 0xFA filled star in titles) survive the trip and the JS
+// side decides how to render them.
+static void emit_json_str(const char *key, const char *s) {
+    const unsigned char *p;
+    emitf("\"%s\":\"", key);
+    for (p = (const unsigned char *) s; *p != '\0'; p++) {
+        if (*p == '"' || *p == '\\') {
+            emitf("\\%c", *p);
+        } else if (*p >= 0x20 && *p < 0x7F) {
+            emitf("%c", *p);
+        } else {
+            emitf("\\u%04x", *p);
+        }
+    }
+    emitf("\"");
+}
+
+// ---------------------------------------------------------------------------
+// Exports.
+
+EMSCRIPTEN_KEEPALIVE
+s32 gen_num_objective_types(void) {
+    return BINGO_OBJECTIVE_TOTAL_AMOUNT;
+}
+
+EMSCRIPTEN_KEEPALIVE
+const char *gen_version(void) {
+    return GEN_VERSION;
+}
+
+// One entry per objective type, for building the options screen.
+EMSCRIPTEN_KEEPALIVE
+const char *gen_options_json(void) {
+    enum BingoObjectiveType t;
+    char label[64];
+    int first = 1;
+
+    sLen = 0;
+    emitf("[");
+    for (t = BINGO_OBJECTIVE_TYPE_MIN; t < BINGO_OBJECTIVE_TOTAL_AMOUNT; t++) {
+        struct BingoObjectiveInfo *info = get_objective_info(t);
+        if (info == NULL) {
+            continue;
+        }
+        reverse_encode_str(info->optionText, label);
+        emitf(first ? "{" : ",{");
+        first = 0;
+        emitf("\"type\":%d,\"icon\":%d,", info->type, info->icon);
+        emit_json_str("label", label);
+        emitf("}");
+    }
+    emitf("]");
+    return sBuf;
+}
+
+// Raw 16x16 RGBA16 texture bytes (512 of them) for a board icon.
+EMSCRIPTEN_KEEPALIVE
+const u8 *gen_icon_rgba16(s32 icon) {
+    struct BingoObjectiveInfo *info = get_objective_info_from_icon(icon);
+    return info != NULL ? info->texture : NULL;
+}
+
+static void emit_cell_json(int i) {
+    struct BingoObjective *o = &gBingoObjectives[i];
+    char text[600];
+
+    emitf("{\"type\":%d,\"class\":%d,\"icon\":%d,", o->type, o->class, o->icon);
+    emit_json_str("title", o->title);
+    emitf(",");
+    describe_objective(o, text);
+    emit_json_str("desc", text);
+
+    switch (o->type) {
+        case BINGO_OBJECTIVE_STAR:
+        case BINGO_OBJECTIVE_STAR_TTC_RANDOM:
+        case BINGO_OBJECTIVE_STAR_REVERSE_JOYSTICK:
+        case BINGO_OBJECTIVE_STAR_GREEN_DEMON:
+        case BINGO_OBJECTIVE_STAR_DAREDEVIL:
+            emitf(",\"course\":%d,\"star\":%d",
+                  o->data.starObjective.course, o->data.starObjective.starIndex);
+            break;
+        case BINGO_OBJECTIVE_STAR_A_BUTTON_CHALLENGE:
+        case BINGO_OBJECTIVE_STAR_B_BUTTON_CHALLENGE:
+        case BINGO_OBJECTIVE_STAR_Z_BUTTON_CHALLENGE:
+            emitf(",\"course\":%d,\"star\":%d,",
+                  o->data.abcStarObjective.course, o->data.abcStarObjective.starIndex);
+            emit_json_str("hint", o->data.abcStarObjective.hint ? o->data.abcStarObjective.hint : "");
+            break;
+        case BINGO_OBJECTIVE_STAR_TIMED:
+            emitf(",\"course\":%d,\"star\":%d,\"maxTime\":%d",
+                  o->data.starTimerObjective.course, o->data.starTimerObjective.starIndex,
+                  o->data.starTimerObjective.maxTime);
+            break;
+        case BINGO_OBJECTIVE_STAR_CLICK_GAME:
+            emitf(",\"course\":%d,\"star\":%d,\"maxClicks\":%d",
+                  o->data.starClicksObjective.course, o->data.starClicksObjective.starIndex,
+                  o->data.starClicksObjective.maxClicks);
+            break;
+        case BINGO_OBJECTIVE_COIN:
+        case BINGO_OBJECTIVE_1UPS_IN_LEVEL:
+        case BINGO_OBJECTIVE_STARS_IN_LEVEL:
+        case BINGO_OBJECTIVE_RANDOM_RED_COINS:
+        case BINGO_OBJECTIVE_SPLATOON:
+            emitf(",\"course\":%d,\"toGet\":%d",
+                  o->data.courseCollectableData.course, o->data.courseCollectableData.toGet);
+            break;
+        case BINGO_OBJECTIVE_DANGEROUS_WALL_KICKS:
+            emitf(",\"toGetTotal\":%d,\"toGetEachCourse\":%d",
+                  o->data.multiCourseCollectableData.toGetTotal,
+                  o->data.multiCourseCollectableData.toGetEachCourse);
+            break;
+        case BINGO_OBJECTIVE_BOWSER:
+            emitf(",\"level\":%d", o->data.levelData.level);
+            break;
+        default:
+            emitf(",\"toGet\":%d", o->data.collectableData.toGet);
+            break;
+    }
+    emitf("}");
+}
+
+// The 25 cells in the same order the game draws them: cell (row i, col j)
+// is gBingoObjectives[5 * i + j].
+EMSCRIPTEN_KEEPALIVE
+const char *gen_board_json(u32 seed, s32 target, const u8 *disabled) {
+    int i;
+
+    generate(seed, target, disabled);
+
+    sLen = 0;
+    emitf("{\"seed\":%u,\"target\":%d,\"version\":\"%s\",\"cells\":[", seed, target, GEN_VERSION);
+    for (i = 0; i < 25; i++) {
+        if (i > 0) {
+            emitf(",");
+        }
+        emit_cell_json(i);
+    }
+    emitf("]}");
+    return sBuf;
+}
+
+// The exact golden-file format from test/host/test_bingo.c (dump_cell), so
+// the checker can byte-compare this output against the goldens and against
+// the gcc-built oracle. Keep in sync with dump_cell there.
+static void emit_cell_dump(int i) {
+    struct BingoObjective *o = &gBingoObjectives[i];
+
+    emitf("%02d type=%02d class=%d icon=%02d title=\"%s\"",
+          i, o->type, o->class, o->icon, o->title);
+
+    switch (o->type) {
+        case BINGO_OBJECTIVE_STAR:
+        case BINGO_OBJECTIVE_STAR_TTC_RANDOM:
+        case BINGO_OBJECTIVE_STAR_REVERSE_JOYSTICK:
+        case BINGO_OBJECTIVE_STAR_GREEN_DEMON:
+        case BINGO_OBJECTIVE_STAR_DAREDEVIL:
+            emitf(" course=%d star=%d",
+                  o->data.starObjective.course, o->data.starObjective.starIndex);
+            break;
+        case BINGO_OBJECTIVE_STAR_A_BUTTON_CHALLENGE:
+        case BINGO_OBJECTIVE_STAR_B_BUTTON_CHALLENGE:
+        case BINGO_OBJECTIVE_STAR_Z_BUTTON_CHALLENGE:
+            emitf(" course=%d star=%d hint=\"%s\"",
+                  o->data.abcStarObjective.course, o->data.abcStarObjective.starIndex,
+                  o->data.abcStarObjective.hint ? o->data.abcStarObjective.hint : "");
+            break;
+        case BINGO_OBJECTIVE_STAR_TIMED:
+            emitf(" course=%d star=%d maxTime=%d",
+                  o->data.starTimerObjective.course, o->data.starTimerObjective.starIndex,
+                  o->data.starTimerObjective.maxTime);
+            break;
+        case BINGO_OBJECTIVE_STAR_CLICK_GAME:
+            emitf(" course=%d star=%d maxClicks=%d",
+                  o->data.starClicksObjective.course, o->data.starClicksObjective.starIndex,
+                  o->data.starClicksObjective.maxClicks);
+            break;
+        case BINGO_OBJECTIVE_COIN:
+        case BINGO_OBJECTIVE_1UPS_IN_LEVEL:
+        case BINGO_OBJECTIVE_STARS_IN_LEVEL:
+        case BINGO_OBJECTIVE_RANDOM_RED_COINS:
+        case BINGO_OBJECTIVE_SPLATOON:
+            emitf(" course=%d toGet=%d",
+                  o->data.courseCollectableData.course, o->data.courseCollectableData.toGet);
+            break;
+        case BINGO_OBJECTIVE_DANGEROUS_WALL_KICKS:
+            emitf(" toGetTotal=%d toGetEachCourse=%d",
+                  o->data.multiCourseCollectableData.toGetTotal,
+                  o->data.multiCourseCollectableData.toGetEachCourse);
+            break;
+        case BINGO_OBJECTIVE_BOWSER:
+            emitf(" level=%d", o->data.levelData.level);
+            break;
+        default:
+            emitf(" toGet=%d", o->data.collectableData.toGet);
+            break;
+    }
+    emitf("\n");
+}
+
+EMSCRIPTEN_KEEPALIVE
+const char *gen_board_dump(u32 seed, s32 target, const u8 *disabled) {
+    int i;
+
+    generate(seed, target, disabled);
+
+    sLen = 0;
+    for (i = 0; i < 25; i++) {
+        emit_cell_dump(i);
+    }
+    return sBuf;
+}

--- a/web/site/index.html
+++ b/web/site/index.html
@@ -41,6 +41,9 @@
 
     <section id="boardWrap">
       <div id="board"></div>
+      <aside id="cellDetail">
+        <p class="detail-hint">Click a cell to see its objective here.</p>
+      </aside>
     </section>
 
     <details id="descriptionsBox">
@@ -59,7 +62,7 @@
         <label for="goalStyle">Goal text</label>
         <select id="goalStyle">
           <option value="desc">Full descriptions</option>
-          <option value="title">Short in-game titles</option>
+          <option value="title">Short: objective name + title</option>
         </select>
         <button id="copyGoals">Copy goals JSON</button>
       </div>

--- a/web/site/index.html
+++ b/web/site/index.html
@@ -9,7 +9,6 @@
 <body>
   <header>
     <h1>Bingo64 Board Generator</h1>
-    <p class="tagline">The exact board the game makes for a seed &mdash; same C code, compiled to WebAssembly.</p>
   </header>
 
   <main>
@@ -33,8 +32,6 @@
       <summary>Objective options <span id="optionsSummary"></span></summary>
       <div class="options-actions">
         <button id="toggleAll">Toggle all</button>
-        <p>Turn objectives off here exactly like on the game's options screen.
-           The same seed with different options makes a different board.</p>
       </div>
       <div id="optionsList" class="options-list"></div>
     </details>

--- a/web/site/index.html
+++ b/web/site/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bingo64 Board Generator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Bingo64 Board Generator</h1>
+    <p class="tagline">The exact board the game makes for a seed &mdash; same C code, compiled to WebAssembly.</p>
+  </header>
+
+  <main>
+    <section class="controls">
+      <label for="seed">Seed</label>
+      <input id="seed" type="text" inputmode="numeric" maxlength="9" placeholder="0&ndash;999999999">
+      <button id="random">Random</button>
+
+      <label for="target">Game mode</label>
+      <select id="target">
+        <option value="1">1 Bingo</option>
+        <option value="2">2 Bingos</option>
+        <option value="3">3 Bingos</option>
+        <option value="12">Blackout</option>
+      </select>
+
+      <button id="permalink" title="Copy a link to this exact board">Copy link</button>
+    </section>
+
+    <details id="optionsBox">
+      <summary>Objective options <span id="optionsSummary"></span></summary>
+      <div class="options-actions">
+        <button id="toggleAll">Toggle all</button>
+        <p>Turn objectives off here exactly like on the game's options screen.
+           The same seed with different options makes a different board.</p>
+      </div>
+      <div id="optionsList" class="options-list"></div>
+    </details>
+
+    <section id="boardWrap">
+      <div id="board"></div>
+    </section>
+
+    <details id="descriptionsBox">
+      <summary>Cell descriptions</summary>
+      <ol id="descriptions"></ol>
+    </details>
+
+    <section class="bingosync">
+      <h2>Race it on Bingosync</h2>
+      <p>
+        On <a href="https://bingosync.com" target="_blank" rel="noopener">bingosync.com</a>, choose
+        <strong>Make Room</strong>, set Game to <strong>Custom (Advanced)</strong>, and paste the
+        goals below into the Board field.
+      </p>
+      <div class="bingosync-controls">
+        <label for="goalStyle">Goal text</label>
+        <select id="goalStyle">
+          <option value="desc">Full descriptions</option>
+          <option value="title">Short in-game titles</option>
+        </select>
+        <button id="copyGoals">Copy goals JSON</button>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p>Generator version <code id="version"></code> &middot;
+       boards verified against the game's own code &middot;
+       <a href="https://github.com/matt-kempster/bingo64" target="_blank" rel="noopener">bingo64 on GitHub</a></p>
+  </footer>
+
+  <div id="toast" hidden></div>
+
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/web/site/main.js
+++ b/web/site/main.js
@@ -5,6 +5,7 @@ const M = await createModule();
 const NUM_TYPES = M._gen_num_objective_types();
 const VERSION = M.UTF8ToString(M._gen_version());
 const OPTIONS = JSON.parse(M.UTF8ToString(M._gen_options_json()));
+const OPTION_LABELS = new Map(OPTIONS.map((opt) => [opt.type, opt.label]));
 
 // 0xFA is the in-game filled-star glyph; titles carry it as U+00FA.
 const STAR_BYTE = 'ú';
@@ -98,10 +99,41 @@ function iconCanvas(icon) {
 // Rendering.
 
 let currentBoard = null;
+let selectedCell = -1;
+
+const coordOf = (i) => 'ABCDE'[i % 5] + (Math.floor(i / 5) + 1);
+
+function showCellDetail(i) {
+  const panel = $('cellDetail');
+  panel.replaceChildren();
+  if (i < 0) {
+    panel.appendChild(el('p', 'detail-hint', 'Click a cell to see its objective here.'));
+    return;
+  }
+  const cell = currentBoard.cells[i];
+  const head = el('div', 'detail-head');
+  head.appendChild(iconCanvas(cell.icon));
+  const heading = el('div');
+  heading.appendChild(el('div', 'detail-coord', coordOf(i)));
+  heading.appendChild(el('div', 'detail-title', pretty(cell.title)));
+  head.appendChild(heading);
+  panel.appendChild(head);
+  panel.appendChild(el('p', 'detail-desc', cell.desc));
+  panel.appendChild(el('p', 'detail-kind', OPTION_LABELS.get(cell.type) ?? ''));
+}
+
+function selectCell(i) {
+  selectedCell = selectedCell === i ? -1 : i;
+  const cells = $('board').querySelectorAll('.cell');
+  cells.forEach((node, idx) => node.classList.toggle('selected', idx === selectedCell));
+  showCellDetail(selectedCell);
+}
 
 function render() {
   currentBoard = generateBoard();
   writeHash();
+  selectedCell = -1;
+  showCellDetail(-1);
 
   $('seed').value = String(state.seed);
   $('target').value = String(state.target);
@@ -118,6 +150,7 @@ function render() {
     div.title = `${cols[i % 5]}${Math.floor(i / 5) + 1}: ${cell.desc}`;
     div.appendChild(iconCanvas(cell.icon));
     div.appendChild(el('div', 'cell-title', pretty(cell.title)));
+    div.addEventListener('click', () => selectCell(i));
     board.appendChild(div);
   });
 
@@ -191,7 +224,19 @@ async function copyText(text, message) {
 function bingosyncGoals() {
   const useTitle = $('goalStyle').value === 'title';
   return JSON.stringify(
-    currentBoard.cells.map((cell) => ({ name: useTitle ? pretty(cell.title) : cell.desc })),
+    currentBoard.cells.map((cell) => {
+      let name;
+      if (useTitle) {
+        // The bare in-game title ("x6") means nothing off-screen; pair it
+        // with the objective's name from the options menu.
+        name = `${OPTION_LABELS.get(cell.type) ?? '?'}: ${pretty(cell.title)}`;
+      } else {
+        // A fresh board's "Remaining: N" always repeats the count already
+        // stated in the sentence; drop it for Bingosync.
+        name = cell.desc.replace(/\. Remaining: \d+/, '');
+      }
+      return { name };
+    }),
   );
 }
 

--- a/web/site/main.js
+++ b/web/site/main.js
@@ -59,7 +59,13 @@ function generateBoard() {
   M.HEAPU8.fill(0, disabledPtr, disabledPtr + NUM_TYPES);
   for (const t of state.off) M.HEAPU8[disabledPtr + t] = 1;
   const ptr = M._gen_board_json(state.seed, state.target, disabledPtr);
-  return JSON.parse(M.UTF8ToString(ptr));
+  const board = JSON.parse(M.UTF8ToString(ptr));
+  // A fresh board's "Remaining: N" always repeats the count already stated
+  // in the sentence; drop it everywhere.
+  for (const cell of board.cells) {
+    cell.desc = cell.desc.replace(/\. Remaining: \d+/, '');
+  }
+  return board;
 }
 
 // Icon textures are 16x16 RGBA16 (5/5/5/1, big-endian), straight from the
@@ -231,9 +237,7 @@ function bingosyncGoals() {
         // with the objective's name from the options menu.
         name = `${OPTION_LABELS.get(cell.type) ?? '?'}: ${pretty(cell.title)}`;
       } else {
-        // A fresh board's "Remaining: N" always repeats the count already
-        // stated in the sentence; drop it for Bingosync.
-        name = cell.desc.replace(/\. Remaining: \d+/, '');
+        name = cell.desc;
       }
       return { name };
     }),

--- a/web/site/main.js
+++ b/web/site/main.js
@@ -1,0 +1,249 @@
+import createModule from './dist/bingo64gen.mjs';
+
+const M = await createModule();
+
+const NUM_TYPES = M._gen_num_objective_types();
+const VERSION = M.UTF8ToString(M._gen_version());
+const OPTIONS = JSON.parse(M.UTF8ToString(M._gen_options_json()));
+
+// 0xFA is the in-game filled-star glyph; titles carry it as U+00FA.
+const STAR_BYTE = 'ú';
+const pretty = (s) => s.replaceAll(STAR_BYTE, '★');
+
+const $ = (id) => document.getElementById(id);
+
+// ---------------------------------------------------------------------------
+// State: seed, target, set of disabled objective types. Kept in the URL hash
+// so a board can be shared as a link.
+
+const state = {
+  seed: null,
+  target: 1,
+  off: new Set(),
+};
+
+function readHash() {
+  const params = new URLSearchParams(location.hash.slice(1));
+  const s = params.get('s');
+  state.seed = s !== null && /^\d{1,9}$/.test(s) ? Number(s) : randomSeed();
+  const t = Number(params.get('t'));
+  state.target = [1, 2, 3, 12].includes(t) ? t : 1;
+  state.off = new Set(
+    (params.get('off') ?? '')
+      .split(',')
+      .filter((part) => part !== '') // ''.split(',') is [''], and Number('') is 0
+      .map(Number)
+      .filter((n) => Number.isInteger(n) && n >= 0 && n < NUM_TYPES),
+  );
+}
+
+function writeHash() {
+  const params = new URLSearchParams();
+  params.set('s', String(state.seed));
+  if (state.target !== 1) params.set('t', String(state.target));
+  if (state.off.size > 0) params.set('off', [...state.off].sort((a, b) => a - b).join(','));
+  history.replaceState(null, '', '#' + params.toString());
+}
+
+function randomSeed() {
+  return Math.floor(Math.random() * 1000000000);
+}
+
+// ---------------------------------------------------------------------------
+// Generator calls.
+
+const disabledPtr = M._malloc(NUM_TYPES);
+
+function generateBoard() {
+  M.HEAPU8.fill(0, disabledPtr, disabledPtr + NUM_TYPES);
+  for (const t of state.off) M.HEAPU8[disabledPtr + t] = 1;
+  const ptr = M._gen_board_json(state.seed, state.target, disabledPtr);
+  return JSON.parse(M.UTF8ToString(ptr));
+}
+
+// Icon textures are 16x16 RGBA16 (5/5/5/1, big-endian), straight from the
+// compiled game data.
+const iconCache = new Map();
+
+function iconImageData(icon) {
+  if (iconCache.has(icon)) return iconCache.get(icon);
+  const ptr = M._gen_icon_rgba16(icon);
+  let img = null;
+  if (ptr !== 0) {
+    const bytes = M.HEAPU8.subarray(ptr, ptr + 16 * 16 * 2);
+    img = new ImageData(16, 16);
+    for (let i = 0; i < 256; i++) {
+      const px = (bytes[i * 2] << 8) | bytes[i * 2 + 1];
+      img.data[i * 4 + 0] = ((px >> 11) & 0x1f) * 255 / 31;
+      img.data[i * 4 + 1] = ((px >> 6) & 0x1f) * 255 / 31;
+      img.data[i * 4 + 2] = ((px >> 1) & 0x1f) * 255 / 31;
+      img.data[i * 4 + 3] = (px & 1) * 255;
+    }
+  }
+  iconCache.set(icon, img);
+  return img;
+}
+
+function iconCanvas(icon) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 16;
+  canvas.height = 16;
+  canvas.className = 'icon';
+  const img = iconImageData(icon);
+  if (img) canvas.getContext('2d').putImageData(img, 0, 0);
+  return canvas;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering.
+
+let currentBoard = null;
+
+function render() {
+  currentBoard = generateBoard();
+  writeHash();
+
+  $('seed').value = String(state.seed);
+  $('target').value = String(state.target);
+
+  const board = $('board');
+  board.replaceChildren();
+  const cols = 'ABCDE';
+  // Header row: corner + column letters.
+  board.appendChild(el('div', 'coord'));
+  for (let j = 0; j < 5; j++) board.appendChild(el('div', 'coord', cols[j]));
+  currentBoard.cells.forEach((cell, i) => {
+    if (i % 5 === 0) board.appendChild(el('div', 'coord', String(i / 5 + 1)));
+    const div = el('div', 'cell');
+    div.title = `${cols[i % 5]}${Math.floor(i / 5) + 1}: ${cell.desc}`;
+    div.appendChild(iconCanvas(cell.icon));
+    div.appendChild(el('div', 'cell-title', pretty(cell.title)));
+    board.appendChild(div);
+  });
+
+  const descs = $('descriptions');
+  descs.replaceChildren();
+  currentBoard.cells.forEach((cell, i) => {
+    const li = el('li');
+    li.appendChild(el('span', 'coord-label', `${cols[i % 5]}${Math.floor(i / 5) + 1}`));
+    li.appendChild(el('span', null, cell.desc));
+    descs.appendChild(li);
+  });
+
+  const offCount = state.off.size;
+  $('optionsSummary').textContent = offCount > 0 ? `(${offCount} turned off)` : '';
+}
+
+function el(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function buildOptionsList() {
+  const list = $('optionsList');
+  list.replaceChildren();
+  for (const opt of OPTIONS) {
+    const label = el('label', 'option');
+    const box = document.createElement('input');
+    box.type = 'checkbox';
+    box.checked = !state.off.has(opt.type);
+    box.addEventListener('change', () => {
+      if (box.checked) state.off.delete(opt.type);
+      else state.off.add(opt.type);
+      render();
+    });
+    label.appendChild(box);
+    label.appendChild(iconCanvas(opt.icon));
+    label.appendChild(el('span', null, opt.label));
+    list.appendChild(label);
+  }
+}
+
+function syncOptionCheckboxes() {
+  const boxes = $('optionsList').querySelectorAll('input');
+  OPTIONS.forEach((opt, i) => {
+    boxes[i].checked = !state.off.has(opt.type);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Clipboard helpers.
+
+function toast(message) {
+  const node = $('toast');
+  node.textContent = message;
+  node.hidden = false;
+  clearTimeout(toast.timer);
+  toast.timer = setTimeout(() => { node.hidden = true; }, 1800);
+}
+
+async function copyText(text, message) {
+  try {
+    await navigator.clipboard.writeText(text);
+    toast(message);
+  } catch {
+    toast('Copy failed - is the page served over http(s)?');
+  }
+}
+
+function bingosyncGoals() {
+  const useTitle = $('goalStyle').value === 'title';
+  return JSON.stringify(
+    currentBoard.cells.map((cell) => ({ name: useTitle ? pretty(cell.title) : cell.desc })),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Wiring.
+
+$('random').addEventListener('click', () => {
+  state.seed = randomSeed();
+  render();
+});
+
+$('seed').addEventListener('change', () => {
+  const raw = $('seed').value.trim();
+  if (/^\d{1,9}$/.test(raw)) {
+    state.seed = Number(raw);
+    render();
+  } else {
+    toast('Seed must be 1-9 digits');
+    $('seed').value = String(state.seed);
+  }
+});
+
+$('target').addEventListener('change', () => {
+  state.target = Number($('target').value);
+  render();
+});
+
+$('toggleAll').addEventListener('click', () => {
+  if (state.off.size < NUM_TYPES) {
+    for (const opt of OPTIONS) state.off.add(opt.type);
+  } else {
+    state.off.clear();
+  }
+  syncOptionCheckboxes();
+  render();
+});
+
+$('permalink').addEventListener('click', () => {
+  copyText(location.href, 'Link copied');
+});
+
+$('copyGoals').addEventListener('click', () => {
+  copyText(bingosyncGoals(), 'Bingosync goals copied');
+});
+
+window.addEventListener('hashchange', () => {
+  readHash();
+  syncOptionCheckboxes();
+  render();
+});
+
+$('version').textContent = VERSION;
+readHash();
+buildOptionsList();
+render();

--- a/web/site/style.css
+++ b/web/site/style.css
@@ -34,8 +34,6 @@ h1 {
   letter-spacing: 0.02em;
 }
 
-.tagline { margin: 6px 0 0; color: var(--dim); }
-
 h2 { font-size: 1.1rem; margin: 0 0 8px; }
 
 a { color: var(--accent-2); }
@@ -117,6 +115,7 @@ summary:hover { color: var(--text); }
   flex: 1 1 200px;
   max-width: 240px;
   min-height: 120px;
+  margin-top: 24px; /* header row (20px) + grid gap, to align with cell tops */
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 8px;
@@ -147,6 +146,8 @@ summary:hover { color: var(--text); }
 #board {
   display: grid;
   grid-template-columns: 1.2em repeat(5, minmax(86px, 110px));
+  /* Fixed header-row height so the detail panel can line up with the cells. */
+  grid-template-rows: 20px;
   gap: 4px;
   align-items: stretch;
 }

--- a/web/site/style.css
+++ b/web/site/style.css
@@ -1,0 +1,203 @@
+:root {
+  --bg: #10121a;
+  --panel: #1a1e2c;
+  --panel-2: #232840;
+  --line: #343b5c;
+  --text: #e8e9f0;
+  --dim: #9aa0b8;
+  --accent: #ffd53d;
+  --accent-2: #4da6ff;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  line-height: 1.45;
+}
+
+header, main, footer {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+
+header { padding-top: 28px; text-align: center; }
+
+h1 {
+  margin: 0;
+  font-size: 1.9rem;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+}
+
+.tagline { margin: 6px 0 0; color: var(--dim); }
+
+h2 { font-size: 1.1rem; margin: 0 0 8px; }
+
+a { color: var(--accent-2); }
+
+button, select, input[type="text"] {
+  font: inherit;
+  color: var(--text);
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 6px 10px;
+}
+
+button { cursor: pointer; }
+button:hover { border-color: var(--accent); }
+
+input#seed { width: 9.5em; font-variant-numeric: tabular-nums; }
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 22px 0 12px;
+  justify-content: center;
+}
+
+.controls label { color: var(--dim); }
+
+details {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  margin: 12px 0;
+  padding: 8px 12px;
+}
+
+summary { cursor: pointer; color: var(--dim); }
+summary:hover { color: var(--text); }
+
+.options-actions {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin: 10px 0 4px;
+}
+
+.options-actions p { margin: 0; color: var(--dim); font-size: 0.85rem; }
+
+.options-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 2px 14px;
+  margin-top: 8px;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 4px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.option:hover { background: var(--panel-2); }
+.option .icon { width: 20px; height: 20px; }
+
+#boardWrap { display: flex; justify-content: center; margin: 16px 0; }
+
+#board {
+  display: grid;
+  grid-template-columns: 1.2em repeat(5, minmax(86px, 110px));
+  gap: 4px;
+  align-items: stretch;
+}
+
+.coord {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--dim);
+  font-size: 0.8rem;
+}
+
+.cell {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 10px 4px 8px;
+  min-height: 86px;
+  cursor: help;
+}
+
+.cell:hover { border-color: var(--accent); background: var(--panel-2); }
+
+.icon {
+  width: 40px;
+  height: 40px;
+  image-rendering: pixelated;
+}
+
+.cell-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: center;
+  word-break: break-word;
+}
+
+#descriptions { margin: 8px 0 4px; padding-left: 0.5em; list-style: none; }
+
+#descriptions li { margin: 3px 0; color: var(--text); }
+
+.coord-label {
+  display: inline-block;
+  min-width: 2em;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.bingosync {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin: 16px 0;
+}
+
+.bingosync p { margin: 4px 0 10px; color: var(--dim); }
+
+.bingosync-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.bingosync-controls label { color: var(--dim); }
+
+footer {
+  text-align: center;
+  color: var(--dim);
+  font-size: 0.85rem;
+  padding-bottom: 28px;
+}
+
+footer code { color: var(--text); }
+
+#toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--accent);
+  color: #201c00;
+  font-weight: 600;
+  padding: 8px 18px;
+  border-radius: 20px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.5);
+}

--- a/web/site/style.css
+++ b/web/site/style.css
@@ -20,7 +20,7 @@ body {
 }
 
 header, main, footer {
-  max-width: 720px;
+  max-width: 860px;
   margin: 0 auto;
   padding: 0 16px;
 }
@@ -104,7 +104,45 @@ summary:hover { color: var(--text); }
 .option:hover { background: var(--panel-2); }
 .option .icon { width: 20px; height: 20px; }
 
-#boardWrap { display: flex; justify-content: center; margin: 16px 0; }
+#boardWrap {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin: 16px 0;
+}
+
+#cellDetail {
+  flex: 1 1 200px;
+  max-width: 240px;
+  min-height: 120px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px 14px;
+  position: sticky;
+  top: 12px;
+}
+
+.detail-hint { margin: 0; color: var(--dim); font-size: 0.9rem; }
+
+.detail-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.detail-head .icon { width: 32px; height: 32px; }
+
+.detail-coord { color: var(--accent); font-weight: 700; font-size: 0.8rem; }
+
+.detail-title { font-weight: 700; }
+
+.detail-desc { margin: 0 0 8px; font-size: 0.95rem; }
+
+.detail-kind { margin: 0; color: var(--dim); font-size: 0.85rem; }
 
 #board {
   display: grid;
@@ -132,10 +170,16 @@ summary:hover { color: var(--text); }
   gap: 4px;
   padding: 10px 4px 8px;
   min-height: 86px;
-  cursor: help;
+  cursor: pointer;
 }
 
 .cell:hover { border-color: var(--accent); background: var(--panel-2); }
+
+.cell.selected {
+  border-color: var(--accent);
+  background: var(--panel-2);
+  box-shadow: 0 0 0 1px var(--accent);
+}
 
 .icon {
   width: 40px;


### PR DESCRIPTION
Part A of plans/online-bingo.md, plus the Bingosync goal export from part B.

- `web/gen` compiles the real bingo sources to WebAssembly with Emscripten, reusing the `test/host` stub layer (with the real course/act name tables so descriptions use real level and star names). No hand port.
- `web/site` is a static page: seed + game mode + all 41 objective toggles (the same inputs as file select), the 5x5 board with real in-game icons and titles, click-a-cell detail panel, shareable permalinks, and Bingosync "Custom (Advanced)" goals JSON export.
- `make -C web check` proves equivalence: 3 golden boards byte-exact, 200 random seeds, and 60 option combinations against the gcc oracle (whose `BOARD_SEED` mode now also takes `BOARD_TARGET` and `BOARD_DISABLE`). The `web-check` workflow runs this on every PR, no baserom needed.
- The `web-deploy` workflow publishes the site to GitHub Pages on every master push (Pages is already enabled): merging this PR deploys https://matt-kempster.github.io/bingo64/. The two baserom-derived HUD textures (star, coin) are injected from repository variables so deployed icons are real; nothing baserom-derived is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)